### PR TITLE
Fixing the default directory

### DIFF
--- a/KindleClippings.py
+++ b/KindleClippings.py
@@ -175,9 +175,9 @@ if __name__ == "__main__":
     if args.source[-4:] == ".txt":
         source_file = args.source
     elif args.source[-1] == "/":
-        source_file = args.source + "documents/My Clippings.txt"
+        source_file = args.source + "/My Clippings.txt"
     else:
-        source_file = args.source + "/documents/My Clippings.txt"
+        source_file = args.source + "/My Clippings.txt"
 
     if args.destination[-1] == "/":
         destination = args.destination + "KindleClippings/"


### PR DESCRIPTION
I modified the source so it takes the exact input instead of the input + /documents/.

Also, I would change the "/Volumes/Kindle" to "./" to have it working in every OS, and tell the user to place "My Clippings.txt" in the same folder as the project.