### PR TITLE
Handle invalid formats locally

### DIFF
--- a/KindleClippings.py
+++ b/KindleClippings.py
@@ -151,6 +151,8 @@ def parse_clippings(source_file, end_directory, encoding="utf-8", format="txt", 
     :param end_directory: the output directory where all of organised highlights will go
     :type end_directory: str
     :return: organises kindle highlights by book .
+    :param format: output file format. Only "pdf" or "docx" create additional files.
+                    Any other value is treated as "txt".
     """
 
     # Check that the source file (on the kindle) exists
@@ -205,13 +207,13 @@ def parse_clippings(source_file, end_directory, encoding="utf-8", format="txt", 
                         outfile.write(clip_meta + "\n")
                     outfile.write("\n...\n\n")
 
-    # create additional file based on format
-    if format in ["pdf","docx"]:
+    # create additional files based on requested format
+    if format in ["pdf", "docx"]:
         formatted_out_files = create_file_by_type(end_directory, format, include_clip_meta)
         output_files.update(formatted_out_files)
-    else:
-        print("Invalid format mentioned. Only txt file will be created")
-        args.format = "txt"
+    elif format != "txt":
+        print("Invalid format specified. Defaulting to txt.")
+        format = "txt"
 
     print("\nExported titles:\n")
     for i in output_files:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ One of the many great things about kindles is that you can highlight parts of yo
 
 KindleClippings is a utility born out of personal need, which fetches any highlights that you have made on your kindle, and organises them into plain text files per book. It is run from the command line using:
 
-Can specify *format* which will create additional files of that specified type.
-Currently added support for pdf and docx.
+You can use the `-format` option to generate additional files in that format.
+Only `pdf` and `docx` are supported. Any other value will fall back to plain
+text output.
 
 ```bash
 python KindleClippings.py
@@ -107,11 +108,13 @@ The Meaning of It All - Richard P Feynman.txt
 The Selfish Gene - 30th Anniversary Edition - Richard Dawkins.txt
 ```
 
-format usage: formatter will run after txt file are created so apart from txt file, it will also create file of specified type
+Use the `-format` flag after exporting text files to also create a PDF or DOCX
+version:
 
 ```bash
 python KindleClippings.py -source C:\Kindle -format pdf
 ```
+If any other value is passed to `-format`, the script simply exports text files.
 
 
 ## About


### PR DESCRIPTION
## Summary
- refactor `parse_clippings` to avoid global `args`
- default unknown formats to txt
- document supported formats in README

## Testing
- `python -m py_compile KindleClippings.py`