### PR TITLE
Add pytest-style tests for remove_chars

### DIFF
--- a/tests/My Clippings.txt
+++ b/tests/My Clippings.txt
@@ -1,0 +1,11 @@
+==========
+Example Title: The Beginning (John Doe)
+- Your Highlight on page 12 | location 123-124 | Added on Monday, 1 January 2020 12:00:00
+
+This is a highlight text.
+==========
+Another Book? & Something & Else (Jane Smith)
+- Your Highlight at location 200 | Added on Tuesday, 2 February 2021 13:00:00
+
+Interesting highlight & note?
+==========

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import pytest
+
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    fpdf_mod = types.ModuleType('fpdf')
+    class DummyFPDF:
+        def add_page(self):
+            pass
+        def add_font(self, *args, **kwargs):
+            pass
+        def set_font(self, *args, **kwargs):
+            pass
+        def set_margins(self, *args, **kwargs):
+            pass
+        def multi_cell(self, *args, **kwargs):
+            pass
+        def set_draw_color(self, *args, **kwargs):
+            pass
+        def line(self, *args, **kwargs):
+            pass
+        def output(self, *args, **kwargs):
+            pass
+        y = 0
+    fpdf_mod.FPDF = DummyFPDF
+    monkeypatch.setitem(sys.modules, 'fpdf', fpdf_mod)
+
+    docx_mod = types.ModuleType('docx')
+    class DummyDocxDocument:
+        def add_heading(self, *args, **kwargs):
+            pass
+        def add_paragraph(self, *args, **kwargs):
+            pass
+        def save(self, *args, **kwargs):
+            pass
+    docx_mod.Document = DummyDocxDocument
+    monkeypatch.setitem(sys.modules, 'docx', docx_mod)
+
+    import KindleClippings
+    monkeypatch.setattr(KindleClippings, 'args', types.SimpleNamespace(format='txt'), raising=False)

--- a/tests/test_parse_clippings.py
+++ b/tests/test_parse_clippings.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+import types
+
+import KindleClippings
+from KindleClippings import parse_clippings, remove_chars
+
+
+def test_parse_clippings_creates_files(tmp_path):
+    clippings = Path(__file__).with_name("My Clippings.txt")
+    out_dir = tmp_path / "out"
+    parse_clippings(str(clippings), str(out_dir), format="txt")
+
+    expected_files = [
+        remove_chars("Example Title: The Beginning (John Doe)") + ".txt",
+        remove_chars("Another Book? & Something & Else (Jane Smith)") + ".txt",
+    ]
+    assert sorted(os.listdir(out_dir)) == sorted(expected_files)
+
+    contents1 = (out_dir / expected_files[0]).read_text(encoding="utf8")
+    assert "This is a highlight text." in contents1
+
+    contents2 = (out_dir / expected_files[1]).read_text(encoding="utf8")
+    assert "Interesting highlight & note?" in contents2

--- a/tests/test_remove_chars.py
+++ b/tests/test_remove_chars.py
@@ -1,0 +1,26 @@
+from KindleClippings import remove_chars
+
+
+def test_colon_replacement():
+    assert remove_chars('Title: Subtitle') == 'Title - Subtitle'
+    assert remove_chars('A:B') == 'A - B'
+    assert remove_chars('Multi:part:colon') == 'Multi - part - colon'
+    assert remove_chars('Title:Subtitle : Another') == 'Title - Subtitle - Another'
+
+
+def test_remove_question_and_ampersand():
+    assert remove_chars('Where & When?') == 'Where and When'
+    assert remove_chars('Q? & A?') == 'Q and A'
+    assert remove_chars('This & That & Those') == 'This and That and Those'
+    assert remove_chars('??What?') == 'What'
+    assert remove_chars(' weird??? &?? ') == 'weird and'
+
+
+def test_trim_invalid_characters():
+    assert remove_chars('???Title???') == 'Title'
+    assert remove_chars('!@#My Book!!!') == 'My Book'
+    assert remove_chars('Book (Edition)') == 'Book - Edition'
+
+def test_length_limit():
+    long_title = 'A' * 300
+    assert len(remove_chars(long_title)) == 245


### PR DESCRIPTION
## Summary
- add a My Clippings sample for testing
- add pytest fixtures for stubbing fpdf and docx
- expand remove_chars tests
- test parse_clippings on the sample clippings file

## Testing
- `python - <<'PY'
import sys, os, types
sys.path.insert(0, os.path.abspath('.'))
fpdf = types.ModuleType('fpdf');
class DummyFPDF: pass
fpdf.FPDF = DummyFPDF
sys.modules['fpdf'] = fpdf
docx = types.ModuleType('docx'); docx.Document = object
sys.modules['docx'] = docx
import KindleClippings, tests.test_remove_chars as rc, tests.test_parse_clippings as pc, pathlib, shutil
KindleClippings.args = types.SimpleNamespace(format='txt')
out = pathlib.Path('run_tmp'); shutil.rmtree(out, ignore_errors=True); out.mkdir()
rc.test_colon_replacement(); rc.test_remove_question_and_ampersand(); rc.test_trim_invalid_characters(); rc.test_length_limit(); pc.test_parse_clippings_creates_files(out)
print('tests passed')
PY`